### PR TITLE
Fixed AudioData trimmer

### DIFF
--- a/Sound/AudioData.cs
+++ b/Sound/AudioData.cs
@@ -333,7 +333,7 @@ namespace GotaSoundIO.Sound {
                 int toTrim = samplesToTrim;
                 while (toTrim > 0) {
                     int cutSamples = Math.Min(Channels[i].Last().SampleCount(), toTrim);
-                    Channels[i].Last().Trim(cutSamples);
+                    Channels[i].Last().Trim(totalSamples);
                     toTrim -= cutSamples;
                     if (Channels[i].Last().SampleCount() == 0) {
                         Channels[i].Remove(Channels[i].Last());


### PR DESCRIPTION
Tiny fix. Was probably a typo but it prevented me from importing WAVs with NS2.
Target size of the final samples List was being set to the number of samples to trim, rather than to (original length - number of samples to trim)